### PR TITLE
Update webprd003.library.md

### DIFF
--- a/webprd003.library.md
+++ b/webprd003.library.md
@@ -8,3 +8,4 @@ SANs:
 - findingaids.library.emory.edu
 - keep.library.emory.edu
 - pid.emory.edu
+- repose.library.emory.edu


### PR DESCRIPTION
https://repose.library.emory.edu/
results in bad request but the cert view brings up webprd003